### PR TITLE
Add NOT NULL constraints to some cookbook tables

### DIFF
--- a/db/migrate/015_cookbook_versions_constraint_fix.rb
+++ b/db/migrate/015_cookbook_versions_constraint_fix.rb
@@ -1,0 +1,22 @@
+require File.expand_path('../settings', __FILE__)
+
+Sequel.migration do
+  up do
+    alter_table :cookbook_versions do
+      set_column_allow_null(:cookbook_id, false)
+    end
+    alter_table :cookbook_version_checksums do
+      set_column_allow_null(:cookbook_version_id, false)
+    end
+  end
+
+  down do
+    alter_table :cookbook_versions do
+      set_column_allow_null(:cookbook_id, true)
+    end
+    alter_table :cookbook_version_checksums do
+      set_column_allow_null(:cookbook_version_id, false)
+    end
+  end
+
+end


### PR DESCRIPTION
The `cookbook_versions` and `cookbook_version_checksums` tables had nullable foreign key columns for linking to their cookbook and cookbook version, respectively.

This is why I don't like fancy SQL DSLs :(

cc @seth @jamesc 
