### PR TITLE
Fix ArgumentError when calling LDAP#initialize.

### DIFF
--- a/lib/opscode/authentication/strategies/ldap.rb
+++ b/lib/opscode/authentication/strategies/ldap.rb
@@ -43,7 +43,7 @@ valid values include [#{SUPPORTED_ENCRYPTION_METHODS.join(', ')}]."
             end
           end
 
-          super
+          super()
         end
 
         # perform authentication via a bind against the configured LDAP instance


### PR DESCRIPTION
In OPC 1.4.2, opscode-account was failing on various API requests with
the following:

```
500 wrong number of arguments(1 for 0) - (ArgumentError)
```

Calling `super` passes all arguments to the superclass's method.
`super()` will pass no arguments.

This commit resolves the error and manual testing has not revealed
further issues.  However, this code has not changed significantly, so
it is not clear what changed to introduce this error.

Further investigation is needed.
