### PR TITLE
[OC-11384] LDAP User Create - don't set :hash_type to :bcrypt

### DIFF
--- a/lib/opscode/models/user.rb
+++ b/lib/opscode/models/user.rb
@@ -155,7 +155,8 @@ module Opscode
 
       def initialize(*args)
         # Default set to bcrypt. Mapper will override this to whatever is persisted
-        @hash_type = HASH_TYPE_BCRYPT
+        @hash_type = external_authentication_enabled? ? nil : HASH_TYPE_BCRYPT
+
         super(*args)
       end
 


### PR DESCRIPTION
When creating new users that are externally authenticated (currently
only LDAP users) don't set the :hash_type of the user object to
:bcrypt (the default). Setting the :hash_type to :bcrypt enforces a
PostgreSQL schema constraint that the :hashed_password field must
also be set. Since the user password information is stored
externally, we're not going to be storing any password information
here. Setting the :hash_type to nil will not enforce any schema
constraints.

/cc @jeremiahsnapp @marcparadise 
