### PR TITLE
Look in opscode-acct db because global groups aren't in sql.

### DIFF
--- a/lib/mixlib/authorization/authz_id_mapper.rb
+++ b/lib/mixlib/authorization/authz_id_mapper.rb
@@ -259,7 +259,8 @@ module Mixlib
 
       def group_authz_id_to_name_lookup_sql(authz_id)
         # some groups are still global; fall back to looking there; we have no way of telling from the authz id
-        name = group_mapper.find_by_authz_id(authz_id).name || group_authz_id_to_name_lookup_couchdb(authz_id)
+        local_group = group_mapper.find_by_authz_id(authz_id)
+        name = (local_group && local_group.name) || group_authz_id_to_name_lookup_couchdb(authz_id)
       end
 
       def group_authz_id_to_name_lookup(authz_id)


### PR DESCRIPTION
@manderson26 said:
Groups can be local to an org, or global. Org local groups are either in the couch chef_GUID database, or in sql with the guid as a key. Global groups are in the couch opscode_account database. 

When looking for a group, we want to check in the org local set (either in couchdb or sql) before looking in the global groups (currently in opscode_account). However the logic for fall though would fail when the local group search returned nil, since there's no #name method on nil. Corrected the logic to actually fall though and lookup the group in opscode_account when the org local
