### PR TITLE
OC-11702 - handle missing groups during authzid mapping

### DIFF
--- a/lib/mixlib/authorization/authz_id_mapper.rb
+++ b/lib/mixlib/authorization/authz_id_mapper.rb
@@ -251,10 +251,10 @@ module Mixlib
         end
       end
 
-
+      # returns nil if the group referenced by authz_id is not found
       def group_authz_id_to_name_lookup_couchdb(authz_id)
         auth_join = AuthJoin.by_auth_object_id(:key=>authz_id).first
-        Mixlib::Authorization::Models::Group.on(couch_db).get(auth_join.user_object_id).groupname
+        auth_join && Mixlib::Authorization::Models::Group.on(couch_db).get(auth_join.user_object_id).groupname
       end
 
       def group_authz_id_to_name_lookup_sql(authz_id)


### PR DESCRIPTION
This commit fixes a bug where opscode-account throws an
exception when trying to map the authz_id for a group that
no longer exists to a name. The bug manifests itself in two
separate ways:
- when a showing a group that contains a group that
  has been deleted
- when showing the ACLs for an object that contains a
  group that has been deleted

/cc @opscode/server-team 
